### PR TITLE
Add Rojo builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - uses: Roblox/setup-foreman@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Runs a single command using the runners shell
+      - name: Build Roblox place file
+        run: rojo build -o Madwork.rbxlx
+        
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Place File
+          path: Madwork.rbxlx
+          

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,0 +1,2 @@
+[tools]
+rojo = { source = "rojo-rbx/rojo", version = "6.0.0" }


### PR DESCRIPTION
This pull request adds a GitHub action that builds Madwork using Rojo and uploads it was a GitHub artifact. An example of this is at the bottom of https://github.com/Dog2puppy/Madwork-Zero/actions/runs/709593290 where you can download a place file. 